### PR TITLE
Remove emoji from metadata file

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -1,5 +1,5 @@
 [package]
-description = Set your logs on fire with Emoji-🔥!
+description = Set your logs on fire with Emoji!
 credits = Jan Grashoefer <jan.grashoefer@gmail.com>,
 	Matthias Grundmann <matthias.grundmann@kit.edu>,
 	Florian Jacob <florian.jacob@kit.edu>


### PR DESCRIPTION
This works around an issue running `zkg` under Python2: the default `configparser` behavior won't handle utf8 encoding in metadata files.

See https://github.com/zeek/package-manager/issues/53

Would be appreciated if you can keep the metadata ascii-only at least until Jan 1, 2020.   At that point, Python2 is EOL and I can feel even less obligated to make code changes in `zkg` to work around the broken `configparser` utf8 handling and just point people to use Python3 whose default behavior currently handles it fine.