### PR TITLE
Use Zeek environment variables for btest.cfg

### DIFF
--- a/testing/btest.cfg
+++ b/testing/btest.cfg
@@ -6,8 +6,8 @@ IgnoreDirs  = .tmp
 IgnoreFiles = *.tmp *.swp
 
 [environment]
-BRO_SEED_FILE=%(testbase)s/random.seed
-BROPATH=`bro-config --bropath`:%(testbase)s/../scripts
+ZEEK_SEED_FILE=%(testbase)s/random.seed
+ZEEKPATH=`zeek-config --zeekpath`:%(testbase)s/../scripts
 TZ=UTC
 LC_ALL=C
 TRACES=%(testbase)s/traces


### PR DESCRIPTION
Otherwise installing/testing via zkg sets an insufficient default
ZEEKPATH, but zeek will prefer that over the correct BROPATH created via
btest.cfg.  i.e. if ZEEKPATH is set, zeek prefers it over BROPATH.